### PR TITLE
fix: add logon param

### DIFF
--- a/artifacts/LogonScript.ps1
+++ b/artifacts/LogonScript.ps1
@@ -1,3 +1,8 @@
+param (
+    [string]$arcFederatedToken,
+    [string]$msiUrl
+)
+
 $SubscriptionId = $env:arcSubscriptionId
 $TenantId = $env:arcTenantId
 $Location = $env:arcLocation


### PR DESCRIPTION
Issue fix

 we're seeing a failure in Ring 0 for AKS-EE cluster type. AKS-EE Logon step is failing with ERROR: argument --federated-token: expected one argument. Is this something you can help with?
[Pipelines - Run int-r0-sh-aks-weu-102258916 logs (visualstudio.com)](https://msazure.visualstudio.com/One/_build/results?buildId=102258916&view=logs&j=1568881b-5861-5b50-72e4-42b13481e6a3&t=5428c44e-7d7d-5a58-c083-a449c0284451)
	             Azure DevOps Services | Sign In